### PR TITLE
fix: avoid pending reset time underflow

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1022,14 +1022,14 @@ impl Pending {
         let current_time = now();
 
         // remove old ids
-        #[allow(clippy::unchecked_time_subtraction)]
-        let max_time = current_time - config.reset_duration;
-        while let Some(item) = inner.queue.front() {
-            if item.1 < max_time {
-                inner.ids.remove(&item.0);
-                inner.queue.pop_front();
-            } else {
-                break;
+        if let Some(max_time) = current_time.checked_sub(config.reset_duration) {
+            while let Some(item) = inner.queue.front() {
+                if item.1 < max_time {
+                    inner.ids.remove(&item.0);
+                    inner.queue.pop_front();
+                } else {
+                    break;
+                }
             }
         }
 
@@ -1070,6 +1070,8 @@ impl Pending {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use ntex::http::{HeaderMap, Method, test, uri::Scheme};
     use ntex::time::{Millis, Seconds, sleep};
     use ntex::{SharedCfg, io::Io, service::fn_service, util::Bytes};
@@ -1091,6 +1093,18 @@ mod tests {
             frame::Frame::GoAway(f) => f,
             _ => panic!("Expect Reset frame: {frm:?}"),
         }
+    }
+
+    #[test]
+    fn test_pending_reset_time_underflow() {
+        let pending = super::Pending::default();
+        let mut config = ServiceConfig::new();
+        config.reset_duration = Duration::MAX;
+        let id = frame::StreamId::CLIENT;
+
+        pending.add(id, &config);
+
+        assert!(pending.is_pending(id));
     }
 
     #[ntex::test]


### PR DESCRIPTION
## Problem

`Pending::add` calculates the expiration threshold for locally reset streams
using direct `Instant` subtraction:

```rust
let max_time = current_time - config.reset_duration;
```

The default reset duration is 30 seconds. On Windows shortly after system
startup, the current `Instant` may not be able to represent a point 30 seconds
in the past. In that case, `Instant - Duration` panics with:

```text
overflow when subtracting duration from instant
```

This was discovered in a Windows auto-start application using `ntex` as its
HTTP client. The failure occurred while completing an HTTP/2 response shortly
after boot. With `panic = "abort"`, the panic terminated the entire process.

Related repositories:

- Reproducer: https://github.com/emmettlu/wallpaper
- `ntex` investigation: https://github.com/emmettlu/ntex

## Fix

Use `Instant::checked_sub` when calculating the expiration threshold:

```rust
if let Some(max_time) = current_time.checked_sub(config.reset_duration) {
    // remove expired stream IDs
}
```

If the subtraction cannot be represented, expiration cleanup is skipped. This
is safe because no pending stream created by the current process can be older
than an unrepresentable threshold.

The size-based cleanup and insertion of the new pending stream still run
normally.

## Performance

This does not add a meaningful cost to the normal path.

`Instant - Duration` is already implemented by the standard library as:

```rust
self.checked_sub(duration).expect(...)
```

The new code uses the same checked operation but handles `None` instead of
panicking.

## Tests

Added a regression test using `Duration::MAX`, which caused the previous
implementation to panic and now completes successfully.

Validation:

```text
cargo test --lib connection::tests::test_pending_reset_time_underflow -- --exact
cargo check --all-targets
cargo clippy --all-targets -- -D warnings
```
